### PR TITLE
Fix selected search option not showing on light theme

### DIFF
--- a/css/roamCSS.css
+++ b/css/roamCSS.css
@@ -363,7 +363,7 @@ strong {
 
 /* fix search actual position*/
 .rm-find-or-create-wrapper .rm-menu-item[style*="background"] {
-    background-color: rgba(255, 255, 255, 0.2) !important;
+    background-color: rgba(var(--color-primary), 0.2) !important;
 }
 
 /* emoji mart fix */


### PR DESCRIPTION
On light themes, the transparent white background for the selected search option doesn't work as expected (as the entire background is white rather than black). 

This changes the background to the primary color so it shows on light and dark themes. 

An alternative would be to add this inside the light theme media selector on the auto-css file if you would like to keep the gray selector on dark mode. 

Hope it is useful! Cheers! 