### PR TITLE
Embeds should look a bit different

### DIFF
--- a/css/roamCSS.css
+++ b/css/roamCSS.css
@@ -197,6 +197,7 @@ div[style*='background: rgb(255, 243, 205)'], div[style*='background: rgb(248, 2
 /* add different background to embedded blocks */
 .rm-embed-container {
   background-color: var(--bg-color) !important;
+  border-radius: 2px;
 }
 
 /* db hover fix */

--- a/css/roamCSS.css
+++ b/css/roamCSS.css
@@ -194,6 +194,11 @@ div[style*='background: rgb(255, 243, 205)'], div[style*='background: rgb(248, 2
     background-color: rgba(var(--color-primary),0.05) !important;
 }
 
+/* add different background to embedded blocks */
+.rm-embed-container {
+  background-color: var(--bg-color) !important;
+}
+
 /* db hover fix */
 .roam-sidebar-container .rm-db-title-container:hover {
 	color: var(--bg-color);


### PR DESCRIPTION
This makes embeds look slightly different so it is obvious it is an embedded block and not just a reference or text on that page. 

New:
![image](https://user-images.githubusercontent.com/17678033/101803021-4e390b00-3acd-11eb-8921-040154af5d66.png)

Old: 
![image](https://user-images.githubusercontent.com/17678033/101803051-58f3a000-3acd-11eb-8681-6698562872ab.png)

Works on dark and light modes. 

Feel free to take or leave these @thesved. I am making some tweaks as I run into them, but they may not be what you want, so no offense if you decline the PR. :) 